### PR TITLE
Add ECAD Forge README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ The directory structure is as follows:
           Project Outputs/       - BOM, rule check reports, Gerbers, pick & place files, PDFs
           Schematics/            - Schematic diagrams
 
+## Hardware Viewer
+
+The PCB layout can be inspected in a browser with [ECAD Forge](https://ecadforge.app/?url=https%3A%2F%2Fgithub.com%2Fmyriadrf%2FLimeSDR-Mini-v2%2Ftree%2Fmain%2Fhardware%2F2v4&document=PCB%2FLimeSDR-Mini_2v4_Rounded.PcbDoc), without installing Altium.
+
 ## Licensing
 
 The hardware designs are licensed under the Solderpad Hardware License v2.1.
-

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The directory structure is as follows:
 
 ## Hardware Viewer
 
-The PCB layout can be inspected in a browser with [ECAD Forge](https://ecadforge.app/?url=https%3A%2F%2Fgithub.com%2Fmyriadrf%2FLimeSDR-Mini-v2%2Ftree%2Fmain%2Fhardware%2F2v4&document=PCB%2FLimeSDR-Mini_2v4_Rounded.PcbDoc), without installing Altium.
+The PCB layout can be inspected in a browser with [ECAD Forge](https://ecadforge.app/?url=https%3A%2F%2Fgithub.com%2Fmyriadrf%2FLimeSDR-Mini-v2%2Ftree%2Fmain%2Fhardware%2F2v4), without installing Altium.
 
 ## Licensing
 


### PR DESCRIPTION
## Summary

This adds a README link to open the PCB layout in ECAD Forge, an online ECAD viewer I built with privacy in mind.

## Background

I used the LimeSDR Altium design files while testing ECAD Forge because they exercise a lot of Altium features. Since the files were helpful as a real-world test case, I thought it might also be useful for others if the README included a direct link to view the PCB in a browser without installing Altium.

I did the same for the old Mini and for the new Micro; PRs will follow.